### PR TITLE
Refactored blendColors (see description for all changes)

### DIFF
--- a/Example/Tests/UIColor+RFBlendingTestCase.swift
+++ b/Example/Tests/UIColor+RFBlendingTestCase.swift
@@ -95,4 +95,85 @@ class UIColor_RFBlendingTestCase: XCTestCase {
         XCTAssertEqual(green, value)
         XCTAssertEqual(blue, value)
     }
+
+    func test_blendColors_withSameDistribution() {
+        let value1: CGFloat = 0.1
+        let value2: CGFloat = 0.6
+        let value3: CGFloat = 0.8
+
+        let color1 = UIColor(red: value1,
+                             green: value1,
+                             blue: value1,
+                             alpha: 1.0)
+        let color2 = UIColor(red: value2,
+                             green: value2,
+                             blue: value2,
+                             alpha: 1.0)
+        let color3 = UIColor(red: value3,
+                             green: value3,
+                             blue: value3,
+                             alpha: 1.0)
+        let color4 = UIColor.blend(colors: [color1, color2, color3])
+
+        let value4: CGFloat = (value1 + value2 + value3) / 3.0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+        XCTAssertNotNil(color4)
+        color4!.getRed(&red,
+                      green: &green,
+                      blue: &blue,
+                      alpha: &alpha)
+
+        XCTAssertEqual(red, value4)
+        XCTAssertEqual(green, value4)
+        XCTAssertEqual(blue, value4)
+    }
+
+    func test_blendColors_withDifferentDistribution() {
+        let value1: CGFloat = 0.2
+        let value2: CGFloat = 0.5
+        let value3: CGFloat = 1.0
+        let dist1: CGFloat = 0.5
+        let dist2: CGFloat = 0.4
+        let dist3: CGFloat = 0.1
+
+        let color1 = UIColor(red: value1,
+                             green: value1,
+                             blue: value1,
+                             alpha: 1.0)
+        let color2 = UIColor(red: value2,
+                             green: value2,
+                             blue: value2,
+                             alpha: 1.0)
+        let color3 = UIColor(red: value3,
+                             green: value3,
+                             blue: value3,
+                             alpha: 1.0)
+        let color4 = UIColor.blend(colors: [color1, color2, color3], at: [dist1, dist2, dist3])
+
+        let value4: CGFloat = (value1 * dist1) + (value2 * dist2) + (value3 * dist3)
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+        XCTAssertNotNil(color4)
+        color4!.getRed(&red,
+                      green: &green,
+                      blue: &blue,
+                      alpha: &alpha)
+
+        XCTAssertEqual(red, value4)
+        XCTAssertEqual(green, value4)
+        XCTAssertEqual(blue, value4)
+    }
+
+    func test_blendColors_withInvalidDistributions() {
+        XCTAssertNil(UIColor.blend(colors: [UIColor.red, UIColor.green, UIColor.blue], at: [0.4, 0.4, 0.4]))
+        XCTAssertNil(UIColor.blend(colors: [UIColor.red, UIColor.green, UIColor.blue], at: [0.3, 0.3, 0.3]))
+        XCTAssertNil(UIColor.blend(colors: [UIColor.red, UIColor.green, UIColor.blue], at: [0.5, 0.5]))
+        XCTAssertNil(UIColor.blend(colors: [UIColor.red, UIColor.green, UIColor.blue], at: [0.2, 0.2, 0.3, 0.3]))
+        XCTAssertNotNil(UIColor.blend(colors: [UIColor.red, UIColor.green, UIColor.blue], at: []))
+    }
 }

--- a/RFUIColor/Classes/UIColor+RFBlending.swift
+++ b/RFUIColor/Classes/UIColor+RFBlending.swift
@@ -48,7 +48,18 @@ extension UIColor {
     ///
     /// - Returns: The new `UIColor` result from the blend.
     public static func blend(colors: [UIColor],
-                             at distribution: [CGFloat] = [CGFloat]()) -> UIColor {
+                             at distribution: [CGFloat] = [CGFloat]()) -> UIColor? {
+        guard colors.count > 0  else {
+            return nil
+        }
+        if distribution.count > 0 {
+            if colors.count != distribution.count {
+                return nil
+            }
+            if distribution.reduce(0.0, +) != 1.0 {
+                return nil
+            }
+        }
         var red: CGFloat = 0.0
         var green: CGFloat = 0.0
         var blue: CGFloat = 0.0
@@ -63,25 +74,15 @@ extension UIColor {
             var blue1: CGFloat = 0.0
             var alpha1: CGFloat = 0.0
             color.getRed(&red1, green: &green1, blue: &blue1, alpha: &alpha1)
-            if distribution.count > i && distributionTotal + distribution[i] <= 1.0 {
-                if distribution[i] > 0.0 {
-                    red += red1 / distribution[i]
-                    green += green1 / distribution[i]
-                    blue += blue1 / distribution[i]
-                    alpha += alpha1 / distribution[i]
-                }
-                distributionTotal += distribution[i]
-            } else {
-                // Equally distribute the remainder of the colors
-                let distribution1: CGFloat = (1.0 - distributionTotal)
-                if distribution1 > 0.0 {
-                    red += red1 / distribution1
-                    green += green1 / distribution1
-                    blue += blue1 / distribution1
-                    alpha += alpha1 / distribution1
-                }
-                distributionTotal += distribution[i]
+            let distributionValue: CGFloat = distribution.count > 0 ? distribution[i] : (1.0 / CGFloat(colors.count))
+            guard distributionTotal + distributionValue <= 1.0, distributionValue >= 0.0 else {
+                return nil
             }
+            red += red1 / distributionValue
+            green += green1 / distributionValue
+            blue += blue1 / distributionValue
+            alpha += alpha1 / distributionValue
+            distributionTotal += distributionValue
         }
         return UIColor(red: red, green: green, blue: blue, alpha: alpha)
     }


### PR DESCRIPTION
Fixes:
- If `distribution` is not valid (e.g. has inconsistent count or is goes over 1.0), then the function fails.
- No longer accepts a partially filled `distribution` value (only covers every `colors` value, or uses the default).
- Groups similar code.